### PR TITLE
fix: CI should now pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
@@ -121,6 +123,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Description
Fixes CI failing due to not picking up rustfmt for ubuntu

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I ran `cargo fmt --all` (code is formatted)
- [X] I ran `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- [X] I ran `cargo test --workspace` (all tests pass)
- [ ] I added tests for new functionality
- [ ] I updated relevant documentation