### PR TITLE
Fix codegen bugs: scalar return propagation, pointer misdetection, bitmask dedup

### DIFF
--- a/vulkan-rust-codegen/src/emit_bitmasks.rs
+++ b/vulkan-rust-codegen/src/emit_bitmasks.rs
@@ -34,10 +34,11 @@ fn emit_bitmask(def: &BitmaskDef) -> TokenStream {
         .iter()
         .filter_map(|b| {
             let rust_name = strip_bit_prefix(&b.name, &prefix)?;
+            let tokens = emit_bit_constant(b, &prefix, is_64)?;
             if !seen.insert(rust_name) {
                 return None;
             }
-            emit_bit_constant(b, &prefix, is_64)
+            Some(tokens)
         })
         .collect();
 
@@ -54,10 +55,11 @@ fn emit_bitmask(def: &BitmaskDef) -> TokenStream {
         .iter()
         .filter_map(|b| {
             let rust_name = strip_bit_prefix(&b.name, &prefix)?;
+            let tokens = emit_debug_check(b, &prefix)?;
             if !seen_debug.insert(rust_name) {
                 return None;
             }
-            emit_debug_check(b, &prefix)
+            Some(tokens)
         })
         .collect();
 
@@ -220,14 +222,15 @@ fn compute_all_value(def: &BitmaskDef, prefix: &str) -> u64 {
         let Some(rust_name) = strip_bit_prefix(&bit.name, prefix) else {
             continue;
         };
+        let val = match &bit.value {
+            BitmaskValue::Bitpos(pos) => 1u64 << pos,
+            BitmaskValue::Value(val) => *val,
+            BitmaskValue::Alias(_) => continue,
+        };
         if !seen.insert(rust_name) {
             continue;
         }
-        match &bit.value {
-            BitmaskValue::Bitpos(pos) => result |= 1u64 << pos,
-            BitmaskValue::Value(val) => result |= val,
-            BitmaskValue::Alias(_) => {}
-        }
+        result |= val;
     }
     result
 }
@@ -411,6 +414,33 @@ mod tests {
             1,
             "expected exactly one SHADER_READ constant"
         );
+    }
+
+    #[test]
+    fn alias_before_real_value_does_not_suppress_constant() {
+        let def = BitmaskDef {
+            name: "ShaderStageFlagBits".to_string(),
+            flags_name: "ShaderStageFlags".to_string(),
+            bitwidth: 32,
+            bits: vec![
+                BitmaskBit {
+                    name: "VK_SHADER_STAGE_TASK_BIT_NV".to_string(),
+                    value: BitmaskValue::Alias("VK_SHADER_STAGE_TASK_BIT_EXT".to_string()),
+                },
+                BitmaskBit {
+                    name: "VK_SHADER_STAGE_TASK_BIT_EXT".to_string(),
+                    value: BitmaskValue::Bitpos(6),
+                },
+            ],
+        };
+        let tokens = emit_bitmask(&def);
+        assert_valid_rust(&tokens);
+        let code = tokens.to_string();
+        assert!(
+            code.contains("pub const TASK"),
+            "TASK constant must be emitted even when alias appears first"
+        );
+        assert!(code.contains("64u32"), "TASK should have value 1<<6 = 64");
     }
 
     #[test]

--- a/vulkan-rust-codegen/src/emit_wrappers.rs
+++ b/vulkan-rust-codegen/src/emit_wrappers.rs
@@ -357,8 +357,22 @@ fn emit_return_type(cmd: &CommandDef, roles: &[ParamRole], pattern: CommandPatte
             let ty = output_base_type(cmd, roles);
             quote! { -> #ty }
         }
+        CommandPattern::Scalar => {
+            let ty = scalar_return_type(cmd);
+            quote! { -> #ty }
+        }
         CommandPattern::ResultOnly => quote! { -> VkResult<()> },
         CommandPattern::Destroy | CommandPattern::VoidForward => TokenStream::new(),
+    }
+}
+
+/// Resolve a `Scalar` command's return type. `VkBool32` is surfaced as `bool`
+/// for consistency with bool output params; all other scalars resolve directly.
+fn scalar_return_type(cmd: &CommandDef) -> TokenStream {
+    if cmd.return_type == "VkBool32" {
+        quote! { bool }
+    } else {
+        resolve_base_type(&cmd.return_type)
     }
 }
 
@@ -479,6 +493,23 @@ fn emit_body(cmd: &CommandDef, roles: &[ParamRole], pattern: CommandPattern) -> 
                 let mut out = unsafe { core::mem::zeroed() };
                 unsafe { fp(#args) };
                 #out_expr
+            }
+        }
+        CommandPattern::Scalar => {
+            let args = emit_call_args(cmd, roles);
+            let call = quote! { unsafe { fp(#args) } };
+            // Parenthesize the call: a bare `unsafe { .. }` block in statement
+            // position followed by `!= 0` is parsed as a statement, not an
+            // expression, which is a syntax error.
+            let ret_expr = if cmd.return_type == "VkBool32" {
+                quote! { (#call) != 0 }
+            } else {
+                call
+            };
+            quote! {
+                #fp_load
+                #bindings
+                #ret_expr
             }
         }
         CommandPattern::Enumerate => {
@@ -911,6 +942,42 @@ mod tests {
     }
 
     #[test]
+    fn return_type_scalar_device_address() {
+        let c = cmd(
+            "vkGetBufferDeviceAddress",
+            "VkDeviceAddress",
+            vec![
+                param("device", "VkDevice"),
+                const_ptr("pInfo", "VkBufferDeviceAddressInfo"),
+            ],
+            DispatchLevel::Device,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        let pattern = classify_command(&c, &roles);
+        let ret = stringify(emit_return_type(&c, &roles, pattern));
+
+        assert_eq!(ret, "-> u64");
+    }
+
+    #[test]
+    fn return_type_scalar_bool32_becomes_bool() {
+        let c = cmd(
+            "vkGetPhysicalDeviceWin32PresentationSupportKHR",
+            "VkBool32",
+            vec![
+                param("physicalDevice", "VkPhysicalDevice"),
+                param("queueFamilyIndex", "uint32_t"),
+            ],
+            DispatchLevel::Instance,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        let pattern = classify_command(&c, &roles);
+        let ret = stringify(emit_return_type(&c, &roles, pattern));
+
+        assert_eq!(ret, "-> bool");
+    }
+
+    #[test]
     fn return_type_void_forward_is_empty() {
         let c = cmd(
             "vkCmdDraw",
@@ -1044,6 +1111,46 @@ mod tests {
         assert!(!body.contains("check"));
         // Last expression is `out`
         assert!(body.ends_with("out }") || body.contains("; out"));
+    }
+
+    #[test]
+    fn body_scalar_returns_call_result() {
+        let c = cmd(
+            "vkGetBufferDeviceAddress",
+            "VkDeviceAddress",
+            vec![
+                param("device", "VkDevice"),
+                const_ptr("pInfo", "VkBufferDeviceAddressInfo"),
+            ],
+            DispatchLevel::Device,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        let pattern = classify_command(&c, &roles);
+        let body = stringify(emit_body(&c, &roles, pattern));
+
+        // No zeroed output; the call itself is the tail expression.
+        assert!(!body.contains("core :: mem :: zeroed"));
+        assert!(body.contains("self . commands () . get_buffer_device_address . expect"));
+        assert!(body.contains("unsafe { fp (self . handle () , p_info) }"));
+        assert!(!body.contains("!= 0"));
+    }
+
+    #[test]
+    fn body_scalar_bool32_compares_to_zero() {
+        let c = cmd(
+            "vkGetPhysicalDeviceWin32PresentationSupportKHR",
+            "VkBool32",
+            vec![
+                param("physicalDevice", "VkPhysicalDevice"),
+                param("queueFamilyIndex", "uint32_t"),
+            ],
+            DispatchLevel::Instance,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        let pattern = classify_command(&c, &roles);
+        let body = stringify(emit_body(&c, &roles, pattern));
+
+        assert!(body.contains("(unsafe { fp (physical_device , queue_family_index) }) != 0"));
     }
 
     #[test]
@@ -1639,6 +1746,7 @@ mod tests {
                     CommandPattern::Enumerate => "Enumerate",
                     CommandPattern::Fill => "Fill",
                     CommandPattern::Query => "Query",
+                    CommandPattern::Scalar => "Scalar",
                     CommandPattern::ResultOnly => "ResultOnly",
                     CommandPattern::VoidForward => "VoidForward",
                 };

--- a/vulkan-rust-codegen/src/wrapper_utils.rs
+++ b/vulkan-rust-codegen/src/wrapper_utils.rs
@@ -79,6 +79,9 @@ pub enum CommandPattern {
     ResultOnly,
     /// void + no output params → `()`
     VoidForward,
+    /// Non-void, non-VkResult scalar return + no output params → `T`
+    /// (e.g. `vkGetBufferDeviceAddress` returning `VkDeviceAddress`).
+    Scalar,
 }
 
 // ---------------------------------------------------------------------------
@@ -384,6 +387,7 @@ fn find_single_output(
 /// type and the roles assigned to its parameters.
 pub fn classify_command(cmd: &CommandDef, roles: &[ParamRole]) -> CommandPattern {
     let has_vk_result = cmd.return_type == "VkResult";
+    let is_void = cmd.return_type == "void";
     let has_output = roles.iter().any(|r| matches!(r, ParamRole::Output));
     let has_output_pair = roles
         .iter()
@@ -407,7 +411,8 @@ pub fn classify_command(cmd: &CommandDef, roles: &[ParamRole]) -> CommandPattern
         (false, true, _, _, _) => CommandPattern::Fill,
         (false, false, _, true, _) => CommandPattern::Query,
         (false, false, _, false, true) => CommandPattern::Destroy,
-        (false, false, _, false, false) => CommandPattern::VoidForward,
+        (false, false, _, false, false) if is_void => CommandPattern::VoidForward,
+        (false, false, _, false, false) => CommandPattern::Scalar,
     }
 }
 
@@ -986,6 +991,54 @@ mod tests {
         );
         let roles = assign_param_roles(&c, &empty_pnext());
         assert_eq!(classify_command(&c, &roles), CommandPattern::ResultOnly);
+    }
+
+    #[test]
+    fn pattern_get_buffer_device_address_is_scalar() {
+        // vkGetBufferDeviceAddress(VkDevice, *const VkBufferDeviceAddressInfo)
+        //     -> VkDeviceAddress
+        let c = cmd(
+            "vkGetBufferDeviceAddress",
+            "VkDeviceAddress",
+            vec![
+                param("device", "VkDevice"),
+                const_ptr("pInfo", "VkBufferDeviceAddressInfo"),
+            ],
+            DispatchLevel::Device,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        // pInfo is a const pointer → Regular, not an output. Scalar return.
+        assert_eq!(classify_command(&c, &roles), CommandPattern::Scalar);
+    }
+
+    #[test]
+    fn pattern_bool32_return_is_scalar() {
+        // vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice, uint32_t)
+        //     -> VkBool32
+        let c = cmd(
+            "vkGetPhysicalDeviceWin32PresentationSupportKHR",
+            "VkBool32",
+            vec![
+                param("physicalDevice", "VkPhysicalDevice"),
+                param("queueFamilyIndex", "uint32_t"),
+            ],
+            DispatchLevel::Instance,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        assert_eq!(classify_command(&c, &roles), CommandPattern::Scalar);
+    }
+
+    #[test]
+    fn pattern_void_return_stays_void_forward() {
+        // A genuine void command with no output must remain VoidForward, not Scalar.
+        let c = cmd(
+            "vkCmdEndRendering",
+            "void",
+            vec![param("commandBuffer", "VkCommandBuffer")],
+            DispatchLevel::Device,
+        );
+        let roles = assign_param_roles(&c, &empty_pnext());
+        assert_eq!(classify_command(&c, &roles), CommandPattern::VoidForward);
     }
 
     #[test]

--- a/vulkan-rust-codegen/tests/regression.rs
+++ b/vulkan-rust-codegen/tests/regression.rs
@@ -788,7 +788,8 @@ fn wrapper_return_types_match_patterns() {
             vulkan_rust_codegen::wrapper_utils::CommandPattern::Fill => {
                 ret.starts_with("Vec<") && !ret.contains("VkResult")
             }
-            vulkan_rust_codegen::wrapper_utils::CommandPattern::Query => {
+            vulkan_rust_codegen::wrapper_utils::CommandPattern::Query
+            | vulkan_rust_codegen::wrapper_utils::CommandPattern::Scalar => {
                 !ret.is_empty() && !ret.contains("VkResult") && !ret.contains("Vec")
             }
             vulkan_rust_codegen::wrapper_utils::CommandPattern::ResultOnly => ret == "VkResult<()>",

--- a/vulkan-rust-sys/src/bitmasks.rs
+++ b/vulkan-rust-sys/src/bitmasks.rs
@@ -149,7 +149,7 @@ impl AccessFlagBits {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(268042239u32)
+        Self(268435455u32)
     }
     ///Bit 0.
     pub const INDIRECT_COMMAND_READ: Self = Self(1u32);
@@ -205,6 +205,10 @@ impl AccessFlagBits {
     pub const FRAGMENT_DENSITY_MAP_READ: Self = Self(16777216u32);
     ///Bit 23.
     pub const FRAGMENT_SHADING_RATE_ATTACHMENT_READ: Self = Self(8388608u32);
+    ///Bit 17.
+    pub const COMMAND_PREPROCESS_READ: Self = Self(131072u32);
+    ///Bit 18.
+    pub const COMMAND_PREPROCESS_WRITE: Self = Self(262144u32);
 }
 impl core::ops::BitOr for AccessFlagBits {
     type Output = Self;
@@ -465,6 +469,22 @@ impl core::fmt::Debug for AccessFlagBits {
             remaining &= !Self::FRAGMENT_SHADING_RATE_ATTACHMENT_READ.0;
             first = false;
         }
+        if remaining & Self::COMMAND_PREPROCESS_READ.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("COMMAND_PREPROCESS_READ")?;
+            remaining &= !Self::COMMAND_PREPROCESS_READ.0;
+            first = false;
+        }
+        if remaining & Self::COMMAND_PREPROCESS_WRITE.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("COMMAND_PREPROCESS_WRITE")?;
+            remaining &= !Self::COMMAND_PREPROCESS_WRITE.0;
+            first = false;
+        }
         if remaining != 0u32 {
             if !first {
                 f.write_str(" | ")?;
@@ -504,7 +524,7 @@ impl AccessFlagBits2 {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(547679931907833855u64)
+        Self(547679931908227071u64)
     }
     pub const _2_NONE: Self = Self(0u64);
     ///Bit 0.
@@ -571,6 +591,10 @@ impl AccessFlagBits2 {
     pub const _2_TRANSFORM_FEEDBACK_COUNTER_WRITE: Self = Self(134217728u64);
     ///Bit 20.
     pub const _2_CONDITIONAL_RENDERING_READ: Self = Self(1048576u64);
+    ///Bit 17.
+    pub const _2_COMMAND_PREPROCESS_READ: Self = Self(131072u64);
+    ///Bit 18.
+    pub const _2_COMMAND_PREPROCESS_WRITE: Self = Self(262144u64);
     ///Bit 23.
     pub const _2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ: Self = Self(8388608u64);
     pub const _2_SHADING_RATE_IMAGE_READ: Self = Self::_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ;
@@ -910,6 +934,22 @@ impl core::fmt::Debug for AccessFlagBits2 {
             }
             f.write_str("_2_CONDITIONAL_RENDERING_READ")?;
             remaining &= !Self::_2_CONDITIONAL_RENDERING_READ.0;
+            first = false;
+        }
+        if remaining & Self::_2_COMMAND_PREPROCESS_READ.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("_2_COMMAND_PREPROCESS_READ")?;
+            remaining &= !Self::_2_COMMAND_PREPROCESS_READ.0;
+            first = false;
+        }
+        if remaining & Self::_2_COMMAND_PREPROCESS_WRITE.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("_2_COMMAND_PREPROCESS_WRITE")?;
+            remaining &= !Self::_2_COMMAND_PREPROCESS_WRITE.0;
             first = false;
         }
         if remaining & Self::_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ.0 != 0 {
@@ -15677,7 +15717,7 @@ impl PipelineStageFlagBits {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(65404927u32)
+        Self(67108863u32)
     }
     ///Bit 0.
     pub const TOP_OF_PIPE: Self = Self(1u32);
@@ -15727,6 +15767,12 @@ impl PipelineStageFlagBits {
     pub const FRAGMENT_DENSITY_PROCESS: Self = Self(8388608u32);
     ///Bit 22.
     pub const FRAGMENT_SHADING_RATE_ATTACHMENT: Self = Self(4194304u32);
+    ///Bit 19.
+    pub const TASK_SHADER: Self = Self(524288u32);
+    ///Bit 20.
+    pub const MESH_SHADER: Self = Self(1048576u32);
+    ///Bit 17.
+    pub const COMMAND_PREPROCESS: Self = Self(131072u32);
 }
 impl core::ops::BitOr for PipelineStageFlagBits {
     type Output = Self;
@@ -15963,6 +16009,30 @@ impl core::fmt::Debug for PipelineStageFlagBits {
             remaining &= !Self::FRAGMENT_SHADING_RATE_ATTACHMENT.0;
             first = false;
         }
+        if remaining & Self::TASK_SHADER.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("TASK_SHADER")?;
+            remaining &= !Self::TASK_SHADER.0;
+            first = false;
+        }
+        if remaining & Self::MESH_SHADER.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("MESH_SHADER")?;
+            remaining &= !Self::MESH_SHADER.0;
+            first = false;
+        }
+        if remaining & Self::COMMAND_PREPROCESS.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("COMMAND_PREPROCESS")?;
+            remaining &= !Self::COMMAND_PREPROCESS.0;
+            first = false;
+        }
         if remaining != 0u32 {
             if !first {
                 f.write_str(" | ")?;
@@ -16002,7 +16072,7 @@ impl PipelineStageFlagBits2 {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(131939246145535u64)
+        Self(131939247849471u64)
     }
     pub const _2_NONE: Self = Self(0u64);
     ///Bit 0.
@@ -16062,6 +16132,8 @@ impl PipelineStageFlagBits2 {
     pub const _2_TRANSFORM_FEEDBACK: Self = Self(16777216u64);
     ///Bit 18.
     pub const _2_CONDITIONAL_RENDERING: Self = Self(262144u64);
+    ///Bit 17.
+    pub const _2_COMMAND_PREPROCESS: Self = Self(131072u64);
     ///Bit 22.
     pub const _2_FRAGMENT_SHADING_RATE_ATTACHMENT: Self = Self(4194304u64);
     pub const _2_SHADING_RATE_IMAGE: Self = Self::_2_FRAGMENT_SHADING_RATE_ATTACHMENT;
@@ -16071,6 +16143,10 @@ impl PipelineStageFlagBits2 {
     pub const _2_RAY_TRACING_SHADER: Self = Self(2097152u64);
     ///Bit 23.
     pub const _2_FRAGMENT_DENSITY_PROCESS: Self = Self(8388608u64);
+    ///Bit 19.
+    pub const _2_TASK_SHADER: Self = Self(524288u64);
+    ///Bit 20.
+    pub const _2_MESH_SHADER: Self = Self(1048576u64);
     ///Bit 39.
     pub const _2_SUBPASS_SHADER_BIT: Self = Self(549755813888u64);
     pub const _2_SUBPASS_SHADING_BIT: Self = Self::_2_SUBPASS_SHADER_BIT;
@@ -16368,6 +16444,14 @@ impl core::fmt::Debug for PipelineStageFlagBits2 {
             remaining &= !Self::_2_CONDITIONAL_RENDERING.0;
             first = false;
         }
+        if remaining & Self::_2_COMMAND_PREPROCESS.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("_2_COMMAND_PREPROCESS")?;
+            remaining &= !Self::_2_COMMAND_PREPROCESS.0;
+            first = false;
+        }
         if remaining & Self::_2_FRAGMENT_SHADING_RATE_ATTACHMENT.0 != 0 {
             if !first {
                 f.write_str(" | ")?;
@@ -16398,6 +16482,22 @@ impl core::fmt::Debug for PipelineStageFlagBits2 {
             }
             f.write_str("_2_FRAGMENT_DENSITY_PROCESS")?;
             remaining &= !Self::_2_FRAGMENT_DENSITY_PROCESS.0;
+            first = false;
+        }
+        if remaining & Self::_2_TASK_SHADER.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("_2_TASK_SHADER")?;
+            remaining &= !Self::_2_TASK_SHADER.0;
+            first = false;
+        }
+        if remaining & Self::_2_MESH_SHADER.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("_2_MESH_SHADER")?;
+            remaining &= !Self::_2_MESH_SHADER.0;
             first = false;
         }
         if remaining & Self::_2_SUBPASS_SHADER_BIT.0 != 0 {
@@ -18198,7 +18298,7 @@ impl RenderingFlagBits {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(495u32)
+        Self(511u32)
     }
     ///Bit 0.
     pub const CONTENTS_SECONDARY_COMMAND_BUFFERS: Self = Self(1u32);
@@ -18208,6 +18308,8 @@ impl RenderingFlagBits {
     pub const RESUMING: Self = Self(4u32);
     ///Bit 3.
     pub const ENABLE_LEGACY_DITHERING: Self = Self(8u32);
+    ///Bit 4.
+    pub const CONTENTS_INLINE: Self = Self(16u32);
     ///Bit 5.
     pub const PER_LAYER_FRAGMENT_DENSITY_BIT: Self = Self(32u32);
     ///Bit 6.
@@ -18298,6 +18400,14 @@ impl core::fmt::Debug for RenderingFlagBits {
             }
             f.write_str("ENABLE_LEGACY_DITHERING")?;
             remaining &= !Self::ENABLE_LEGACY_DITHERING.0;
+            first = false;
+        }
+        if remaining & Self::CONTENTS_INLINE.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("CONTENTS_INLINE")?;
+            remaining &= !Self::CONTENTS_INLINE.0;
             first = false;
         }
         if remaining & Self::PER_LAYER_FRAGMENT_DENSITY_BIT.0 != 0 {
@@ -19661,6 +19771,10 @@ impl ShaderStageFlagBits {
     pub const INTERSECTION: Self = Self(4096u32);
     ///Bit 13.
     pub const CALLABLE: Self = Self(8192u32);
+    ///Bit 6.
+    pub const TASK: Self = Self(64u32);
+    ///Bit 7.
+    pub const MESH: Self = Self(128u32);
     ///Bit 14.
     pub const SUBPASS_SHADING_BIT: Self = Self(16384u32);
     ///Bit 19.
@@ -19811,6 +19925,22 @@ impl core::fmt::Debug for ShaderStageFlagBits {
             }
             f.write_str("CALLABLE")?;
             remaining &= !Self::CALLABLE.0;
+            first = false;
+        }
+        if remaining & Self::TASK.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("TASK")?;
+            remaining &= !Self::TASK.0;
+            first = false;
+        }
+        if remaining & Self::MESH.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("MESH")?;
+            remaining &= !Self::MESH.0;
             first = false;
         }
         if remaining & Self::SUBPASS_SHADING_BIT.0 != 0 {
@@ -20403,7 +20533,7 @@ impl SubgroupFeatureFlagBits {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(1791u32)
+        Self(2047u32)
     }
     ///Bit 0.
     pub const BASIC: Self = Self(1u32);
@@ -20425,6 +20555,8 @@ impl SubgroupFeatureFlagBits {
     pub const ROTATE: Self = Self(512u32);
     ///Bit 10.
     pub const ROTATE_CLUSTERED: Self = Self(1024u32);
+    ///Bit 8.
+    pub const PARTITIONED: Self = Self(256u32);
 }
 impl core::ops::BitOr for SubgroupFeatureFlagBits {
     type Output = Self;
@@ -20555,6 +20687,14 @@ impl core::fmt::Debug for SubgroupFeatureFlagBits {
             }
             f.write_str("ROTATE_CLUSTERED")?;
             remaining &= !Self::ROTATE_CLUSTERED.0;
+            first = false;
+        }
+        if remaining & Self::PARTITIONED.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("PARTITIONED")?;
+            remaining &= !Self::PARTITIONED.0;
             first = false;
         }
         if remaining != 0u32 {
@@ -21173,7 +21313,7 @@ impl SwapchainCreateFlagBitsKHR {
     }
     #[inline]
     pub const fn all() -> Self {
-        Self(711u32)
+        Self(719u32)
     }
     ///Bit 0.
     pub const SPLIT_INSTANCE_BIND_REGIONS: Self = Self(1u32);
@@ -21187,6 +21327,8 @@ impl SwapchainCreateFlagBitsKHR {
     pub const PRESENT_ID_2: Self = Self(64u32);
     ///Bit 7.
     pub const PRESENT_WAIT_2: Self = Self(128u32);
+    ///Bit 3.
+    pub const DEFERRED_MEMORY_ALLOCATION: Self = Self(8u32);
 }
 impl core::ops::BitOr for SwapchainCreateFlagBitsKHR {
     type Output = Self;
@@ -21285,6 +21427,14 @@ impl core::fmt::Debug for SwapchainCreateFlagBitsKHR {
             }
             f.write_str("PRESENT_WAIT_2")?;
             remaining &= !Self::PRESENT_WAIT_2.0;
+            first = false;
+        }
+        if remaining & Self::DEFERRED_MEMORY_ALLOCATION.0 != 0 {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str("DEFERRED_MEMORY_ALLOCATION")?;
+            remaining &= !Self::DEFERRED_MEMORY_ALLOCATION.0;
             first = false;
         }
         if remaining != 0u32 {

--- a/vulkan-rust/examples/push_constants.rs
+++ b/vulkan-rust/examples/push_constants.rs
@@ -541,10 +541,7 @@ unsafe fn record_commands(
             state.pipeline_layout,
             ShaderStageFlags::VERTEX,
             0,
-            std::slice::from_raw_parts(
-                push_data as *const PushConstants as *const u8,
-                std::mem::size_of::<PushConstants>(),
-            ),
+            vulkan_rust::as_bytes(push_data),
         );
 
         let viewport = Viewport {

--- a/vulkan-rust/src/bytecode.rs
+++ b/vulkan-rust/src/bytecode.rs
@@ -1,4 +1,4 @@
-//! SPIR-V bytecode alignment helper.
+//! Byte-level helpers for Vulkan data: SPIR-V alignment and raw struct access.
 
 use std::fmt;
 
@@ -41,6 +41,36 @@ impl fmt::Display for BytecodeError {
 }
 
 impl std::error::Error for BytecodeError {}
+
+/// Reinterprets a reference to a `Copy` type as a byte slice.
+///
+/// This is useful for passing `#[repr(C)]` structs to Vulkan commands
+/// that accept `&[u8]`, such as `cmd_push_constants`.
+///
+/// # Safety
+///
+/// `T` must not contain padding bytes. Reading uninitialized padding is
+/// undefined behavior. Use `#[repr(C)]` structs whose fields leave no
+/// gaps, or verify with `assert_eq!(size_of::<T>(), /* expected */)`.
+///
+/// # Examples
+///
+/// ```
+/// use vulkan_rust::as_bytes;
+///
+/// #[repr(C)]
+/// #[derive(Clone, Copy)]
+/// struct PushData { time: f32, scale: f32 }
+///
+/// let data = PushData { time: 1.0, scale: 2.0 };
+/// let bytes = unsafe { as_bytes(&data) };
+/// assert_eq!(bytes.len(), 8);
+/// ```
+pub unsafe fn as_bytes<T: Copy>(value: &T) -> &[u8] {
+    // SAFETY: caller guarantees T has no padding. Casting to u8 is always
+    // aligned, and the slice covers exactly size_of::<T>() bytes.
+    unsafe { std::slice::from_raw_parts(value as *const T as *const u8, std::mem::size_of::<T>()) }
+}
 
 /// Cast a byte slice to a `u32` slice for `ShaderModuleCreateInfo`.
 ///

--- a/vulkan-rust/src/generated/device_wrappers.rs
+++ b/vulkan-rust/src/generated/device_wrappers.rs
@@ -28,12 +28,15 @@ impl crate::Device {
     ///The returned pointer is only valid for the device it was queried
     ///from. Passing a command name that the device does not support
     ///returns a null pointer.
-    pub unsafe fn get_device_proc_addr(&self, p_name: *const core::ffi::c_char) {
+    pub unsafe fn get_device_proc_addr(
+        &self,
+        p_name: *const core::ffi::c_char,
+    ) -> PFN_vkVoidFunction {
         let fp = self
             .commands()
             .get_device_proc_addr
             .expect("vkGetDeviceProcAddr not loaded");
-        unsafe { fp(self.handle(), p_name) };
+        unsafe { fp(self.handle(), p_name) }
     }
     ///Wraps [`vkDestroyDevice`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkDestroyDevice.html).
     /**
@@ -12798,12 +12801,12 @@ impl crate::Device {
         pipeline: Pipeline,
         group: u32,
         group_shader: ShaderGroupShaderKHR,
-    ) {
+    ) -> u64 {
         let fp = self
             .commands()
             .get_ray_tracing_shader_group_stack_size_khr
             .expect("vkGetRayTracingShaderGroupStackSizeKHR not loaded");
-        unsafe { fp(self.handle(), pipeline, group, group_shader) };
+        unsafe { fp(self.handle(), pipeline, group, group_shader) }
     }
     ///Wraps [`vkCmdSetRayTracingPipelineStackSizeKHR`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkCmdSetRayTracingPipelineStackSizeKHR.html).
     /**
@@ -12864,12 +12867,12 @@ impl crate::Device {
     ///for fully bindless texture access.
     ///
     ///Requires `VK_NVX_image_view_handle`.
-    pub unsafe fn get_image_view_handle_nvx(&self, p_info: &ImageViewHandleInfoNVX) {
+    pub unsafe fn get_image_view_handle_nvx(&self, p_info: &ImageViewHandleInfoNVX) -> u32 {
         let fp = self
             .commands()
             .get_image_view_handle_nvx
             .expect("vkGetImageViewHandleNVX not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkGetImageViewHandle64NVX`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetImageViewHandle64NVX.html).
     /**
@@ -12888,12 +12891,12 @@ impl crate::Device {
     ///`get_image_view_handle_nvx`.
     ///
     ///Requires `VK_NVX_image_view_handle`.
-    pub unsafe fn get_image_view_handle64_nvx(&self, p_info: &ImageViewHandleInfoNVX) {
+    pub unsafe fn get_image_view_handle64_nvx(&self, p_info: &ImageViewHandleInfoNVX) -> u64 {
         let fp = self
             .commands()
             .get_image_view_handle64_nvx
             .expect("vkGetImageViewHandle64NVX not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkGetImageViewAddressNVX`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetImageViewAddressNVX.html).
     /**
@@ -12949,12 +12952,12 @@ impl crate::Device {
         &self,
         image_view_index: u64,
         sampler_index: u64,
-    ) {
+    ) -> u64 {
         let fp = self
             .commands()
             .get_device_combined_image_sampler_index_nvx
             .expect("vkGetDeviceCombinedImageSamplerIndexNVX not loaded");
-        unsafe { fp(self.handle(), image_view_index, sampler_index) };
+        unsafe { fp(self.handle(), image_view_index, sampler_index) }
     }
     ///Wraps [`vkGetDeviceGroupSurfacePresentModes2EXT`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetDeviceGroupSurfacePresentModes2EXT.html).
     /**
@@ -13186,12 +13189,15 @@ impl crate::Device {
     ///Most applications do not need this, it is primarily for debugging
     ///and profiling tools. Use `get_buffer_device_address` for runtime
     ///buffer address access.
-    pub unsafe fn get_buffer_opaque_capture_address(&self, p_info: &BufferDeviceAddressInfo) {
+    pub unsafe fn get_buffer_opaque_capture_address(
+        &self,
+        p_info: &BufferDeviceAddressInfo,
+    ) -> u64 {
         let fp = self
             .commands()
             .get_buffer_opaque_capture_address
             .expect("vkGetBufferOpaqueCaptureAddress not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkGetBufferDeviceAddress`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetBufferDeviceAddress.html).
     /**
@@ -13226,12 +13232,12 @@ impl crate::Device {
     ///buffer was created with
     ///`BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY`, the address can be
     ///captured and replayed across sessions.
-    pub unsafe fn get_buffer_device_address(&self, p_info: &BufferDeviceAddressInfo) {
+    pub unsafe fn get_buffer_device_address(&self, p_info: &BufferDeviceAddressInfo) -> u64 {
         let fp = self
             .commands()
             .get_buffer_device_address
             .expect("vkGetBufferDeviceAddress not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkInitializePerformanceApiINTEL`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkInitializePerformanceApiINTEL.html).
     /**
@@ -13557,12 +13563,12 @@ impl crate::Device {
     pub unsafe fn get_device_memory_opaque_capture_address(
         &self,
         p_info: &DeviceMemoryOpaqueCaptureAddressInfo,
-    ) {
+    ) -> u64 {
         let fp = self
             .commands()
             .get_device_memory_opaque_capture_address
             .expect("vkGetDeviceMemoryOpaqueCaptureAddress not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkGetPipelineExecutablePropertiesKHR`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetPipelineExecutablePropertiesKHR.html).
     /**
@@ -13995,12 +14001,12 @@ impl crate::Device {
     pub unsafe fn get_acceleration_structure_device_address_khr(
         &self,
         p_info: &AccelerationStructureDeviceAddressInfoKHR,
-    ) {
+    ) -> u64 {
         let fp = self
             .commands()
             .get_acceleration_structure_device_address_khr
             .expect("vkGetAccelerationStructureDeviceAddressKHR not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkCreateDeferredOperationKHR`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkCreateDeferredOperationKHR.html).
     /**
@@ -14106,12 +14112,12 @@ impl crate::Device {
     pub unsafe fn get_deferred_operation_max_concurrency_khr(
         &self,
         operation: DeferredOperationKHR,
-    ) {
+    ) -> u32 {
         let fp = self
             .commands()
             .get_deferred_operation_max_concurrency_khr
             .expect("vkGetDeferredOperationMaxConcurrencyKHR not loaded");
-        unsafe { fp(self.handle(), operation) };
+        unsafe { fp(self.handle(), operation) }
     }
     ///Wraps [`vkGetDeferredOperationResultKHR`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetDeferredOperationResultKHR.html).
     /**
@@ -14245,12 +14251,12 @@ impl crate::Device {
     pub unsafe fn get_pipeline_indirect_device_address_nv(
         &self,
         p_info: &PipelineIndirectDeviceAddressInfoNV,
-    ) {
+    ) -> u64 {
         let fp = self
             .commands()
             .get_pipeline_indirect_device_address_nv
             .expect("vkGetPipelineIndirectDeviceAddressNV not loaded");
-        unsafe { fp(self.handle(), p_info) };
+        unsafe { fp(self.handle(), p_info) }
     }
     ///Wraps [`vkAntiLagUpdateAMD`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkAntiLagUpdateAMD.html).
     /**

--- a/vulkan-rust/src/generated/instance_wrappers.rs
+++ b/vulkan-rust/src/generated/instance_wrappers.rs
@@ -119,12 +119,15 @@ impl crate::Instance {
     ///The returned pointer may go through a loader trampoline. For
     ///device-level commands, `get_device_proc_addr` returns a
     ///driver-direct pointer that is slightly faster.
-    pub unsafe fn get_instance_proc_addr(&self, p_name: *const core::ffi::c_char) {
+    pub unsafe fn get_instance_proc_addr(
+        &self,
+        p_name: *const core::ffi::c_char,
+    ) -> PFN_vkVoidFunction {
         let fp = self
             .commands()
             .get_instance_proc_addr
             .expect("vkGetInstanceProcAddr not loaded");
-        unsafe { fp(self.handle(), p_name) };
+        unsafe { fp(self.handle(), p_name) }
     }
     ///Wraps [`vkGetPhysicalDeviceProperties`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetPhysicalDeviceProperties.html).
     /**
@@ -1244,12 +1247,12 @@ impl crate::Instance {
         &self,
         physical_device: PhysicalDevice,
         queue_family_index: u32,
-    ) {
+    ) -> bool {
         let fp = self
             .commands()
             .get_physical_device_win32_presentation_support_khr
             .expect("vkGetPhysicalDeviceWin32PresentationSupportKHR not loaded");
-        unsafe { fp(physical_device, queue_family_index) };
+        (unsafe { fp(physical_device, queue_family_index) }) != 0
     }
     ///Wraps [`vkGetPhysicalDeviceXlibPresentationSupportKHR`](https://registry.khronos.org/vulkan/specs/latest/man/html/vkGetPhysicalDeviceXlibPresentationSupportKHR.html).
     /**
@@ -3905,11 +3908,11 @@ impl crate::Instance {
         &self,
         physical_device: PhysicalDevice,
         descriptor_type: DescriptorType,
-    ) {
+    ) -> u64 {
         let fp = self
             .commands()
             .get_physical_device_descriptor_size_ext
             .expect("vkGetPhysicalDeviceDescriptorSizeEXT not loaded");
-        unsafe { fp(physical_device, descriptor_type) };
+        unsafe { fp(physical_device, descriptor_type) }
     }
 }

--- a/vulkan-rust/src/lib.rs
+++ b/vulkan-rust/src/lib.rs
@@ -86,7 +86,7 @@ mod surface;
 pub mod test_helpers;
 mod version;
 
-pub use bytecode::{BytecodeError, cast_to_u32};
+pub use bytecode::{BytecodeError, as_bytes, cast_to_u32};
 pub use device::Device;
 pub use entry::Entry;
 pub use error::{LoadError, VkError, VkResult};


### PR DESCRIPTION
## Description

- Fix generated command wrappers incorrectly treating void* input pointer parameters as command return values
- Fix scalar return values (e.g. non-VkResult returns) not being propagated correctly from generated wrappers
- Fix a codegen dedup bug that was suppressing extension bitmask bits from being emitted
- Add an as_bytes utility for safely casting values to byte slices (e.g. for push constants)

## Related Issues
Fixes #45, #47

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
