### PR TITLE
Add cargo-semver-checks job to guard public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,23 @@ jobs:
       - name: Check vulkan-rust
         run: cargo +1.85 check -p vulkan-rust --all-features
 
+  semver:
+    name: SemVer Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libvulkan-dev libxcb1-dev libxkbcommon-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check public API against the last published release
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   clippy:
     name: Clippy Lints
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,9 +1441,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,6 @@ ignore = [
     # paste is unmaintained but only reaches us as a transitive dev-dependency
     # (image -> ravif -> rav1e -> paste). No action needed.
     "RUSTSEC-2024-0436",
-    [advisories]
     # ttf-parser is unmaintained with no maintained upgrade available. Reaches us
     # only as a transitive dev-dependency (winit -> sctk-adwaita -> ab_glyph ->
     # owned_ttf_parser). No safe fix; not a vulnerability.

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,15 @@ ignore = [
     # only as a transitive dev-dependency (winit -> sctk-adwaita -> ab_glyph ->
     # owned_ttf_parser). No safe fix; not a vulnerability.
     "RUSTSEC-2026-0192",
+    # core2 is unmaintained with all versions yanked and no safe upgrade. Reaches
+    # us only as a transitive dev-dependency (image -> ravif -> rav1e ->
+    # bitstream-io -> core2), same chain as the paste advisory above.
+    "RUSTSEC-2026-0105",
+    # quick-xml quadratic-runtime and unbounded-allocation DoS advisories. No fixed
+    # release resolves them for us; reaches us only as a transitive dev-dependency
+    # (winit -> ... -> wayland-scanner -> quick-xml).
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,11 @@ ignore = [
     # paste is unmaintained but only reaches us as a transitive dev-dependency
     # (image -> ravif -> rav1e -> paste). No action needed.
     "RUSTSEC-2024-0436",
+    [advisories]
+    # ttf-parser is unmaintained with no maintained upgrade available. Reaches us
+    # only as a transitive dev-dependency (winit -> sctk-adwaita -> ab_glyph ->
+    # owned_ttf_parser). No safe fix; not a vulnerability.
+    "RUSTSEC-2026-0192",
 ]
 
 [licenses]

--- a/vulkan-rust-codegen/tests/regression.rs
+++ b/vulkan-rust-codegen/tests/regression.rs
@@ -151,7 +151,10 @@ fn two_call_return_type_consistency() {
             vulkan_rust_codegen::wrapper_utils::CommandPattern::Fill
                 if cmd.return_type != "void" =>
             {
-                mismatches.push(format!("{}: Fill but returns '{}'", cmd.name, cmd.return_type));
+                mismatches.push(format!(
+                    "{}: Fill but returns '{}'",
+                    cmd.name, cmd.return_type
+                ));
             }
             _ => {}
         }

--- a/vulkan-rust-codegen/tests/regression.rs
+++ b/vulkan-rust-codegen/tests/regression.rs
@@ -140,21 +140,18 @@ fn two_call_return_type_consistency() {
         let pattern = vulkan_rust_codegen::wrapper_utils::classify_command(cmd, &roles);
 
         match pattern {
-            vulkan_rust_codegen::wrapper_utils::CommandPattern::Enumerate => {
-                if cmd.return_type != "VkResult" {
-                    mismatches.push(format!(
-                        "{}: Enumerate but returns '{}'",
-                        cmd.name, cmd.return_type
-                    ));
-                }
+            vulkan_rust_codegen::wrapper_utils::CommandPattern::Enumerate
+                if cmd.return_type != "VkResult" =>
+            {
+                mismatches.push(format!(
+                    "{}: Enumerate but returns '{}'",
+                    cmd.name, cmd.return_type
+                ));
             }
-            vulkan_rust_codegen::wrapper_utils::CommandPattern::Fill => {
-                if cmd.return_type != "void" {
-                    mismatches.push(format!(
-                        "{}: Fill but returns '{}'",
-                        cmd.name, cmd.return_type
-                    ));
-                }
+            vulkan_rust_codegen::wrapper_utils::CommandPattern::Fill
+                if cmd.return_type != "void" =>
+            {
+                mismatches.push(format!("{}: Fill but returns '{}'", cmd.name, cmd.return_type));
             }
             _ => {}
         }


### PR DESCRIPTION
## Description
Adds cargo-semver-checks job to guard public API.

## Related Issues
Fixes #26 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I ran `cargo fmt --all` (code is formatted)
- [X] I ran `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- [X] I ran `cargo test --workspace` (all tests pass)