### PR TITLE
Update crossbeam-epoch given Rustsec  warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/vulkan-rust-codegen/src/emit_bitmasks.rs
+++ b/vulkan-rust-codegen/src/emit_bitmasks.rs
@@ -18,7 +18,7 @@ pub fn emit_bitmasks(registry: &VkRegistry) -> TokenStream {
 
 fn emit_bitmask(def: &BitmaskDef) -> TokenStream {
     let name = format_ident!("{}", &def.name);
-    let vk_name = format!("Vk{}", &def.name);
+    let vk_name = format!("Vk{}", def.name);
     let is_64 = def.bitwidth == 64;
     let prefix = bitmask_bit_prefix(&def.name);
 

--- a/vulkan-rust-codegen/src/emit_builders.rs
+++ b/vulkan-rust-codegen/src/emit_builders.rs
@@ -77,7 +77,7 @@ fn emit_builder(
         };
         let push_next_doc = format!(
             "Prepend a struct to the pNext chain. See [`{}`]'s **Extended By** section for valid types.",
-            &def.name,
+            def.name,
         );
         quote! {
             #[doc = #push_next_doc]
@@ -97,7 +97,7 @@ fn emit_builder(
 
     let builder_doc = format!(
         "Builder for [`{}`] with lifetime-tied pNext safety.",
-        &def.name
+        def.name
     );
 
     quote! {
@@ -155,7 +155,7 @@ fn emit_plain_builder(def: &StructDef) -> TokenStream {
         .map(|m| emit_setter(m, def))
         .collect();
 
-    let builder_doc = format!("Builder for [`{}`].", &def.name);
+    let builder_doc = format!("Builder for [`{}`].", def.name);
 
     if needs_lifetime {
         quote! {

--- a/vulkan-rust-codegen/src/emit_commands.rs
+++ b/vulkan-rust-codegen/src/emit_commands.rs
@@ -91,7 +91,7 @@ fn emit_pfn_typedef(cmd: &CommandDef) -> TokenStream {
 fn emit_command_docs(cmd: &CommandDef) -> TokenStream {
     let spec_link = format!(
         "[`{name}`](https://registry.khronos.org/vulkan/specs/latest/man/html/{name}.html)",
-        name = &cmd.name,
+        name = cmd.name,
     );
 
     let mut doc_lines: Vec<TokenStream> = vec![quote! { #[doc = #spec_link] }];

--- a/vulkan-rust-codegen/src/emit_enums.rs
+++ b/vulkan-rust-codegen/src/emit_enums.rs
@@ -16,7 +16,7 @@ pub fn emit_enums(registry: &VkRegistry) -> TokenStream {
 
 fn emit_enum(def: &EnumDef) -> TokenStream {
     let name = format_ident!("{}", &def.name);
-    let vk_name = format!("Vk{}", &def.name);
+    let vk_name = format!("Vk{}", def.name);
     let prefix = enum_variant_prefix(&def.name);
 
     let mut seen = HashSet::new();

--- a/vulkan-rust-codegen/src/emit_handles.rs
+++ b/vulkan-rust-codegen/src/emit_handles.rs
@@ -47,7 +47,7 @@ fn emit_handle_trait() -> TokenStream {
 
 fn emit_handle(handle: &HandleDef) -> TokenStream {
     let name = format_ident!("{}", &handle.name);
-    let vk_name = format!("Vk{}", &handle.name);
+    let vk_name = format!("Vk{}", handle.name);
 
     let (repr_type, zero_literal) = if handle.dispatchable {
         (quote! { usize }, quote! { 0usize })

--- a/vulkan-rust-codegen/src/emit_structs.rs
+++ b/vulkan-rust-codegen/src/emit_structs.rs
@@ -160,7 +160,7 @@ fn emit_struct_or_union(
 
 /// Build doc comment lines for a struct or union from vk.xml metadata.
 fn emit_struct_docs(def: &StructDef, extended_by: &HashMap<String, Vec<String>>) -> TokenStream {
-    let vk_name = format!("Vk{}", &def.name);
+    let vk_name = format!("Vk{}", def.name);
     let spec_link = format!(
         "[`{vk_name}`](https://registry.khronos.org/vulkan/specs/latest/man/html/{vk_name}.html)"
     );
@@ -208,7 +208,7 @@ fn emit_struct(
     extended_by: &HashMap<String, Vec<String>>,
 ) -> TokenStream {
     let name = format_ident!("{}", &def.name);
-    let vk_name = format!("Vk{}", &def.name);
+    let vk_name = format!("Vk{}", def.name);
     let docs = emit_struct_docs(def, extended_by);
     let fields = emit_fields_with_docs(&def.members);
     let default_impl = emit_default(def, stype_raw);
@@ -230,7 +230,7 @@ fn emit_struct(
 
 fn emit_union(def: &StructDef, extended_by: &HashMap<String, Vec<String>>) -> TokenStream {
     let name = format_ident!("{}", &def.name);
-    let vk_name = format!("Vk{}", &def.name);
+    let vk_name = format!("Vk{}", def.name);
     let docs = emit_struct_docs(def, extended_by);
     let fields = emit_fields(&def.members);
 

--- a/vulkan-rust-codegen/src/emit_wrappers.rs
+++ b/vulkan-rust-codegen/src/emit_wrappers.rs
@@ -185,7 +185,7 @@ fn emit_method(cmd: &CommandDef, roles: &[ParamRole], pattern: CommandPattern) -
 fn emit_wrapper_docs(cmd: &CommandDef, roles: &[ParamRole]) -> TokenStream {
     let spec_link = format!(
         "Wraps [`{name}`](https://registry.khronos.org/vulkan/specs/latest/man/html/{name}.html).",
-        name = &cmd.name,
+        name = cmd.name,
     );
 
     let mut doc_lines: Vec<TokenStream> = vec![quote! { #[doc = #spec_link] }];
@@ -228,7 +228,7 @@ fn emit_wrapper_docs(cmd: &CommandDef, roles: &[ParamRole]) -> TokenStream {
     let panic_cmd = format!(
         "Panics if `{}` was not loaded. This can happen if the required \
          extension or Vulkan version is not enabled on the instance or device.",
-        &cmd.name,
+        cmd.name,
     );
     doc_lines.push(quote! { #[doc = ""] });
     doc_lines.push(quote! { #[doc = "# Panics"] });
@@ -236,7 +236,7 @@ fn emit_wrapper_docs(cmd: &CommandDef, roles: &[ParamRole]) -> TokenStream {
 
     // Doc overrides: append hand-written content from doc_overrides/{vkCommandName}.md.
     let overrides_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("doc_overrides");
-    let override_path = overrides_dir.join(format!("{}.md", &cmd.name));
+    let override_path = overrides_dir.join(format!("{}.md", cmd.name));
     if override_path.exists()
         && let Ok(content) = std::fs::read_to_string(&override_path)
     {


### PR DESCRIPTION
## Description
Cross-beam epoch 09.18 had an invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer was invalid, which was a vulnerability. Cross-beam epoch version 0.9.20 fixes this.
